### PR TITLE
CR-12409

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.3.4-cap-CR-12409-resource-manifest-revison
+2.3.4-cap-CR-12409-resource-manifest-revision

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.3.4-cap-CR-12110-helm-resources-yaml
+2.3.4-cap-CR-12409-resource-manifest-revison

--- a/server/application/application_event_reporter.go
+++ b/server/application/application_event_reporter.go
@@ -363,13 +363,19 @@ func getResourceEventPayload(
 		}
 	}
 
+	revision := a.Status.Sync.Revision
+
+	if !isApp(*rs) {
+		revision = manifestsResponse.Revision
+	}
+
 	source := events.ObjectSource{
 		DesiredManifest: desiredState.CompiledManifest,
 		ActualManifest:  actualState.Manifest,
 		GitManifest:     desiredState.RawManifest,
 		RepoURL:         a.Status.Sync.ComparedTo.Source.RepoURL,
 		Path:            desiredState.Path,
-		Revision:        a.Status.Sync.Revision,
+		Revision:        revision,
 		CommitMessage:   manifestsResponse.CommitMessage,
 		CommitAuthor:    manifestsResponse.CommitAuthor,
 		CommitDate:      manifestsResponse.CommitDate,

--- a/server/application/application_event_reporter.go
+++ b/server/application/application_event_reporter.go
@@ -292,6 +292,13 @@ func logWithAppStatus(a *appv1.Application, logCtx *log.Entry, ts string) *log.E
 	})
 }
 
+func getRevision(a *appv1.Application, rs *appv1.ResourceStatus, manifestsResponse *apiclient.ManifestResponse) string {
+	if !isApp(*rs) {
+		return manifestsResponse.Revision
+	}
+	return a.Status.Sync.Revision
+}
+
 func getResourceEventPayload(
 	a *appv1.Application,
 	rs *appv1.ResourceStatus,
@@ -363,19 +370,13 @@ func getResourceEventPayload(
 		}
 	}
 
-	revision := a.Status.Sync.Revision
-
-	if !isApp(*rs) {
-		revision = manifestsResponse.Revision
-	}
-
 	source := events.ObjectSource{
 		DesiredManifest: desiredState.CompiledManifest,
 		ActualManifest:  actualState.Manifest,
 		GitManifest:     desiredState.RawManifest,
 		RepoURL:         a.Status.Sync.ComparedTo.Source.RepoURL,
 		Path:            desiredState.Path,
-		Revision:        revision,
+		Revision:        getRevision(a, rs, manifestsResponse),
 		CommitMessage:   manifestsResponse.CommitMessage,
 		CommitAuthor:    manifestsResponse.CommitAuthor,
 		CommitDate:      manifestsResponse.CommitDate,

--- a/server/application/application_event_reporter_test.go
+++ b/server/application/application_event_reporter_test.go
@@ -2,8 +2,9 @@ package application
 
 import (
 	"encoding/json"
-	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"testing"
+
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/server/application/application_event_reporter_test.go
+++ b/server/application/application_event_reporter_test.go
@@ -2,12 +2,13 @@ package application
 
 import (
 	"encoding/json"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
+	apppkg "github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/events"
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/reposerver/apiclient"
@@ -20,7 +21,7 @@ func TestGetResourceEventPayload(t *testing.T) {
 		rs := v1alpha1.ResourceStatus{}
 		es := events.EventSource{}
 
-		actualState := application.ApplicationResourceResponse{
+		actualState := apppkg.ApplicationResourceResponse{
 			Manifest: "{ \"key\" : \"manifest\" }",
 		}
 		desiredState := apiclient.Manifest{
@@ -51,7 +52,7 @@ func TestGetResourceEventPayload(t *testing.T) {
 		rs := v1alpha1.ResourceStatus{}
 		es := events.EventSource{}
 
-		actualState := application.ApplicationResourceResponse{
+		actualState := apppkg.ApplicationResourceResponse{
 			Manifest: "{ \"key\" : \"manifest\" }",
 		}
 		desiredState := apiclient.Manifest{
@@ -70,5 +71,49 @@ func TestGetResourceEventPayload(t *testing.T) {
 
 		assert.Equal(t, "", eventPayload.Source.DesiredManifest)
 		assert.Equal(t, "", eventPayload.Source.ActualManifest)
+	})
+}
+
+func TestGetRevision(t *testing.T) {
+	t.Run("application", func(t *testing.T) {
+		app := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync: v1alpha1.SyncStatus{
+					Revision: "a-revision",
+				},
+			},
+		}
+		rs := v1alpha1.ResourceStatus{
+			Group:   application.Group,
+			Version: "v1alpha1",
+			Kind:    application.ApplicationKind,
+		}
+		manifestResponse := apiclient.ManifestResponse{
+			Revision: "mr-revision",
+		}
+		revision := getRevision(&app, &rs, &manifestResponse)
+		assert.Equal(t, revision, "a-revision")
+	})
+
+	t.Run("application", func(t *testing.T) {
+		app := v1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				DeletionTimestamp: &metav1.Time{},
+			},
+			Status: v1alpha1.ApplicationStatus{
+				Sync: v1alpha1.SyncStatus{
+					Revision: "a-revision",
+				},
+			},
+		}
+		rs := v1alpha1.ResourceStatus{}
+		manifestResponse := apiclient.ManifestResponse{
+			Revision: "mr-revision",
+		}
+		revision := getRevision(&app, &rs, &manifestResponse)
+		assert.Equal(t, revision, "mr-revision")
 	})
 }


### PR DESCRIPTION
[application resource reporter]: fixed revision data for resource. No…w, we're sending manifest.revision, so only commit SHA when resource was changed

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

