### PR TITLE
CR-13198

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.3.4-cap-CR-12256-fix-res-cache-key
+2.3.4-cap-CR-13198-resource-cache-payload

--- a/server/cache/cache.go
+++ b/server/cache/cache.go
@@ -24,6 +24,11 @@ type Cache struct {
 	loginAttemptsExpiration         time.Duration
 }
 
+type ResourceCachedState struct {
+	appSyncStatus  *appv1.SyncStatus
+	resourceStatus *appv1.ResourceStatus
+}
+
 func NewCache(
 	cache *appstatecache.Cache,
 	connectionStatusCacheExpiration time.Duration,
@@ -80,11 +85,15 @@ func (c *Cache) GetLastApplicationEvent(a *appv1.Application) (*appv1.Applicatio
 }
 
 func (c *Cache) SetLastResourceEvent(a *appv1.Application, rs appv1.ResourceStatus, exp time.Duration, revision string) error {
-	return c.cache.SetItem(lastResourceEventKey(a, rs, revision), rs, exp, false)
+	payload := ResourceCachedState{
+		appSyncStatus:  &a.Status.Sync,
+		resourceStatus: &rs,
+	}
+	return c.cache.SetItem(lastResourceEventKey(a, rs, revision), payload, exp, false)
 }
 
-func (c *Cache) GetLastResourceEvent(a *appv1.Application, rs appv1.ResourceStatus, revision string) (appv1.ResourceStatus, error) {
-	res := appv1.ResourceStatus{}
+func (c *Cache) GetLastResourceEvent(a *appv1.Application, rs appv1.ResourceStatus, revision string) (ResourceCachedState, error) {
+	res := ResourceCachedState{}
 	return res, c.cache.GetItem(lastResourceEventKey(a, rs, revision), &res)
 }
 


### PR DESCRIPTION
[cache.go]: updated resource cache payload, so now resources like ConfigMap will always have actual date in source object, and will not stuck in Syncing status

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

