### PR TITLE
CR-15658-message

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.4.15-cap-fix-kustomize
+2.4.15-cap-CR-15658-sync-result-message

--- a/controller/sync.go
+++ b/controller/sync.go
@@ -271,20 +271,8 @@ func (m *appStateManager) SyncAppState(app *v1alpha1.Application, state *v1alpha
 	var resState []common.ResourceSyncResult
 	state.Phase, state.Message, resState = syncCtx.GetState()
 	state.SyncResult.Resources = nil
-	for _, res := range resState {
-		state.SyncResult.Resources = append(state.SyncResult.Resources, &v1alpha1.ResourceResult{
-			HookType:  res.HookType,
-			Group:     res.ResourceKey.Group,
-			Kind:      res.ResourceKey.Kind,
-			Namespace: res.ResourceKey.Namespace,
-			Name:      res.ResourceKey.Name,
-			Version:   res.Version,
-			SyncPhase: res.SyncPhase,
-			HookPhase: res.HookPhase,
-			Status:    res.Status,
-			Message:   res.Message,
-		})
-	}
+
+	m.FixWrongKubectlMessage(resState, state, compareResult)
 
 	logEntry.WithField("duration", time.Since(start)).Info("sync/terminate complete")
 

--- a/controller/sync_customizations.go
+++ b/controller/sync_customizations.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"encoding/json"
+	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
+	"github.com/argoproj/gitops-engine/pkg/diff"
+	"github.com/argoproj/gitops-engine/pkg/sync/common"
+	"github.com/argoproj/gitops-engine/pkg/utils/kube"
+	kubeutil "github.com/argoproj/gitops-engine/pkg/utils/kube"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"strings"
+)
+
+// for some resource kubectl apply returns 'configured' in message but in fact it was unchanged
+// this func intented to fix this behaviour
+func (m *appStateManager) FixWrongKubectlMessage(resState []common.ResourceSyncResult, state *v1alpha1.OperationState, compareResult *comparisonResult) {
+	diffResultsMap := groupDiffResults(compareResult.diffResultList)
+
+	for _, res := range resState {
+		message := res.Message
+		resDiff := diffResultsMap[res.ResourceKey]
+
+		configured := "configured"
+		unchanged := "unchanged"
+
+		if message != "" {
+			if strings.HasSuffix(message, configured) && resDiff.Modified == false {
+				message = strings.TrimSuffix(message, configured)
+				message += unchanged
+			}
+		}
+		state.SyncResult.Resources = append(state.SyncResult.Resources, &v1alpha1.ResourceResult{
+			HookType:  res.HookType,
+			Group:     res.ResourceKey.Group,
+			Kind:      res.ResourceKey.Kind,
+			Namespace: res.ResourceKey.Namespace,
+			Name:      res.ResourceKey.Name,
+			Version:   res.Version,
+			SyncPhase: res.SyncPhase,
+			HookPhase: res.HookPhase,
+			Status:    res.Status,
+			Message:   message,
+		})
+	}
+}
+
+// generates a map of resource and its modification result based on diffResultList
+func groupDiffResults(diffResultList *diff.DiffResultList) map[kubeutil.ResourceKey]diff.DiffResult {
+	modifiedResources := make(map[kube.ResourceKey]diff.DiffResult)
+	for _, res := range diffResultList.Diffs {
+		var obj unstructured.Unstructured
+		var err error
+		if string(res.NormalizedLive) != "null" {
+			err = json.Unmarshal(res.NormalizedLive, &obj)
+		} else {
+			err = json.Unmarshal(res.PredictedLive, &obj)
+		}
+		if err != nil {
+			continue
+		}
+		modifiedResources[kube.GetResourceKey(&obj)] = res
+	}
+	return modifiedResources
+}

--- a/controller/sync_customizations.go
+++ b/controller/sync_customizations.go
@@ -24,7 +24,7 @@ func (m *appStateManager) FixWrongKubectlMessage(resState []common.ResourceSyncR
 		unchanged := "unchanged"
 
 		if message != "" {
-			if strings.HasSuffix(message, configured) && resDiff.Modified == false {
+			if strings.HasSuffix(message, configured) && !resDiff.Modified {
 				message = strings.TrimSuffix(message, configured)
 				message += unchanged
 			}


### PR DESCRIPTION
[ sync.go ]: fixed issue when wrong message of 'kubectl apply' action were return in syncResults.resources.message

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/tree/master/community#contributing-to-argo)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 

