### PR TITLE
Revert "Release 2.4 fix appset (#188)"

### DIFF
--- a/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
+++ b/manifests/base/applicationset-controller/argocd-applicationset-controller-deployment.yaml
@@ -18,8 +18,8 @@ spec:
       containers:
         - command:
             - entrypoint.sh
-            - applicationset-controller
-          image: quay.io/codefresh/applicationset:latest
+            - argocd-applicationset-controller
+          image: quay.io/argoproj/argocd:latest
           imagePullPolicy: Always
           name: argocd-applicationset-controller
           ports:
@@ -43,6 +43,13 @@ spec:
             name: gpg-keyring
           - mountPath: /tmp
             name: tmp
+          securityContext:
+           capabilities:
+             drop:
+             - ALL
+           allowPrivilegeEscalation: false
+           readOnlyRootFilesystem: true 
+           runAsNonRoot: true
       serviceAccountName: argocd-applicationset-controller
       volumes:
       - configMap:

--- a/manifests/ha/install.yaml
+++ b/manifests/ha/install.yaml
@@ -10979,7 +10979,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/codefresh/applicationset:latest
+        image: quay.io/codefresh/argocd:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
         ports:

--- a/manifests/install.yaml
+++ b/manifests/install.yaml
@@ -10051,13 +10051,13 @@ spec:
       containers:
       - command:
         - entrypoint.sh
-        - applicationset-controller
+        - argocd-applicationset-controller
         env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/codefresh/applicationset:latest
+        image: quay.io/codefresh/argocd:latest
         imagePullPolicy: Always
         name: argocd-applicationset-controller
         ports:
@@ -10065,6 +10065,13 @@ spec:
           name: webhook
         - containerPort: 8080
           name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /app/config/ssh
           name: ssh-known-hosts
@@ -10478,6 +10485,7 @@ spec:
         volumeMounts:
         - mountPath: /var/run/argocd
           name: var-files
+      serviceAccountName: argocd-repo-server
       volumes:
       - configMap:
           name: argocd-ssh-known-hosts-cm


### PR DESCRIPTION
This reverts commit c430db412ef7b1a44e97dd8474cabae398220496.

There is no explanation as to why this change was made in the PR which created this commit, and it is in direct conflict with how the upstream ArgoCD project manages `applicationset-controller`, which relies on the same container image as `argocd-server`.

The image that the reverted commit refers to comes from a repo / tag that is almost a year stale, and was marked as deprecated _prior_ to the generation of this image: https://github.com/codefresh-io/applicationset/releases/tag/v0.4.2

https://github.com/codefresh-io/applicationset/blame/master/README.md#L3-L5


For additional context, I am currently running the latest vanilla image from ArgoCD without issue: 
```
quay.io/argoproj/argocd:v2.6.1
```
