### PR TITLE
fix: bug with skip-current-step

### DIFF
--- a/resource_customizations/argoproj.io/Rollout/actions/skip-current-step/action.lua
+++ b/resource_customizations/argoproj.io/Rollout/actions/skip-current-step/action.lua
@@ -1,9 +1,9 @@
 if obj.status ~= nil then
     if obj.spec.strategy.canary ~= nil and obj.spec.strategy.canary.steps ~= nil and obj.status.currentStepIndex < table.getn(obj.spec.strategy.canary.steps) then
-        obj.status.pauseConditions = nil
-        obj.spec.pause = false
+        if obj.status.pauseConditions ~= nil and table.getn(obj.status.pauseConditions) > 0 then
+            obj.status.pauseConditions = nil
+        end
         obj.status.currentStepIndex = obj.status.currentStepIndex + 1
-        obj.status.controllerPause = false
     end
 end
 return obj


### PR DESCRIPTION
We have observed a bug in the `skip-current-step` action that manifests itself when the current step is `Paused` due to `InconclusiveAnalysisRun`. Although executing the action moves the `currentStepIndex` forward, the rollout remains `Paused`. We then have to run the `resume` action to unpause the rollout.

I have found by experimentation that the reason the rollout remains paused is because the `skip-current-step` action sets `obj.status.controllerPause` to `false`. The `controllerPause` variable is not meant to be modified – it's sufficient to set `obj.status.pauseConditions` to `nil`. When `pauseConditions` is the only variable modified by the action, `skip-current-step` works properly for us and we don't experience the bug described above.

In addition, the `obj.spec.pause = false` operation is incorrect, because the rollout specification defines `obj.spec.paused` (with the letter `d`). In addition, `obj.spec.paused` indicates a manual pause (triggered by a user, rather than by the rollout controller) and it's debatable if `skip-current-step` should resume a manual pause. The `resume` action can be used for that purpose. I have therefore removed that line entirely. 

I have also added an additional if statement that checks if `obj.status.pauseConditions` is defined and has at least one element. Otherwise the variable isn't touched. This logic is modeled on the `resume` action.

Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] The title of the PR conforms to the [Toolchain Guide](https://argo-cd.readthedocs.io/en/latest/developer-guide/toolchain-guide/#title-of-the-pr)
* [ ] I've included "Closes [ISSUE #]" or "Fixes [ISSUE #]" in the description to automatically close the associated issue.
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Does this PR require documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md#legal)
* [ ] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/latest/developer-guide/ci/)). 
* [ ] My new feature complies with the [feature status](https://github.com/argoproj/argoproj/blob/master/community/feature-status.md) guidelines.
* [ ] I have added a brief description of why this PR is necessary and/or what this PR solves.

Please see [Contribution FAQs](https://argo-cd.readthedocs.io/en/latest/developer-guide/faq/) if you have questions about your pull-request.
