### PR TITLE
feat: update revision for path should not affect sync

### DIFF
--- a/controller/state.go
+++ b/controller/state.go
@@ -235,16 +235,18 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 				HasMultipleSources: app.Spec.HasMultipleSources(),
 			})
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to compare revisions for source %d of %d: %w", i+1, len(sources), err)
+				logCtx.Warnf("failed to generate manifest for source %d of %d: %v", i+1, len(sources), err)
 			}
 
-			if updateRevisionResult.Changes {
-				revisionUpdated = true
-			}
+			if updateRevisionResult != nil {
+				if updateRevisionResult.Changes {
+					revisionUpdated = true
+				}
 
-			// Generate manifests should use same revision as updateRevisionForPaths, because HEAD revision may be different between these two calls
-			if updateRevisionResult.Revision != "" {
-				revision = updateRevisionResult.Revision
+				// Generate manifests should use same revision as updateRevisionForPaths, because HEAD revision may be different between these two calls
+				if updateRevisionResult.Revision != "" {
+					revision = updateRevisionResult.Revision
+				}
 			}
 		} else {
 			// revisionUpdated is set to true if at least one revision is not possible to be updated,
@@ -278,7 +280,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 			ApplicationMetadata: &app.ObjectMeta,
 		})
 		if err != nil {
-			logCtx.Warnf("failed to generate manifest for source %d of %d: %v", i+1, len(sources), err)
+			return nil, nil, false, fmt.Errorf("failed to generate manifest for source %d of %d: %w", i+1, len(sources), err)
 		}
 
 		targetObj, err := unmarshalManifests(manifestInfo.GetCompiledManifests())

--- a/controller/state.go
+++ b/controller/state.go
@@ -189,6 +189,8 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 
 	keyManifestGenerateAnnotationVal, keyManifestGenerateAnnotationExists := app.Annotations[v1alpha1.AnnotationKeyManifestGeneratePaths]
 
+	logCtx := log.WithField("application", app.QualifiedName())
+	
 	for i, source := range sources {
 		if len(revisions) < len(sources) || revisions[i] == "" {
 			revisions[i] = source.TargetRevision
@@ -233,8 +235,11 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 				HasMultipleSources: app.Spec.HasMultipleSources(),
 			})
 			if err != nil {
+				
+				
 				return nil, nil, false, fmt.Errorf("failed to compare revisions for source %d of %d: %w", i+1, len(sources), err)
 			}
+		 	
 			if updateRevisionResult.Changes {
 				revisionUpdated = true
 			}
@@ -275,7 +280,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 			ApplicationMetadata: &app.ObjectMeta,
 		})
 		if err != nil {
-			return nil, nil, false, fmt.Errorf("failed to generate manifest for source %d of %d: %w", i+1, len(sources), err)
+			logCtx.Warnf("failed to generate manifest for source %d of %d: %v", i+1, len(sources), err)
 		}
 
 		targetObj, err := unmarshalManifests(manifestInfo.GetCompiledManifests())
@@ -287,7 +292,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 	}
 
 	ts.AddCheckpoint("unmarshal_ms")
-	logCtx := log.WithField("application", app.QualifiedName())
+	
 	for k, v := range ts.Timings() {
 		logCtx = logCtx.WithField(k, v.Milliseconds())
 	}

--- a/controller/state.go
+++ b/controller/state.go
@@ -190,7 +190,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 	keyManifestGenerateAnnotationVal, keyManifestGenerateAnnotationExists := app.Annotations[v1alpha1.AnnotationKeyManifestGeneratePaths]
 
 	logCtx := log.WithField("application", app.QualifiedName())
-	
+
 	for i, source := range sources {
 		if len(revisions) < len(sources) || revisions[i] == "" {
 			revisions[i] = source.TargetRevision
@@ -235,11 +235,9 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 				HasMultipleSources: app.Spec.HasMultipleSources(),
 			})
 			if err != nil {
-				
-				
 				return nil, nil, false, fmt.Errorf("failed to compare revisions for source %d of %d: %w", i+1, len(sources), err)
 			}
-		 	
+
 			if updateRevisionResult.Changes {
 				revisionUpdated = true
 			}
@@ -292,7 +290,7 @@ func (m *appStateManager) GetRepoObjs(app *v1alpha1.Application, sources []v1alp
 	}
 
 	ts.AddCheckpoint("unmarshal_ms")
-	
+
 	for k, v := range ts.Timings() {
 		logCtx = logCtx.WithField(k, v.Milliseconds())
 	}


### PR DESCRIPTION
In case if UpdateRevisionForPaths failed with error, sync still should happens, just to HEAD 

Related to https://codefresh-io.atlassian.net/browse/CR-25777