### PR TITLE
fix: validate destination request always fails

### DIFF
--- a/server/application/application_validate_src_and_dest.go
+++ b/server/application/application_validate_src_and_dest.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/argoproj/argo-cd/v3/pkg/apiclient/application"
@@ -73,22 +71,5 @@ func validateDestination(ctx context.Context, dest *appv1.ApplicationDestination
 		return errors.New("no destination defined in app spec")
 	}
 	_, err := argo.GetDestinationCluster(ctx, *dest, db)
-	if err != nil {
-		return err
-	}
-
-	if dest.Server != "" {
-		// Ensure the k8s cluster the app is referencing, is configured in Argo CD
-		_, err := db.GetCluster(ctx, dest.Server)
-		if err != nil {
-			if errStatus, ok := status.FromError(err); ok && errStatus.Code() == codes.NotFound {
-				return fmt.Errorf("cluster '%s' has not been configured", dest.Server)
-			}
-			return err
-		}
-	} else if dest.Server == "" {
-		return errors.New("destination server missing from app spec")
-	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
We previously used validateDestination from OSS, which adds missing fields (server / name) to provided spec.destionation of an application. In 3.x.x validateDestination method was removed, and new one already performs all check and throws not found error in case if server of name are not correct.